### PR TITLE
Increase the best_width 

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -322,7 +322,7 @@ func yaml_emitter_emit_stream_start(emitter *yaml_emitter_t, event *yaml_event_t
 	}
 
 	if emitter.best_width >= 0 && emitter.best_width <= emitter.best_indent*2 {
-		emitter.best_width = 80
+		emitter.best_width = 512
 	}
 
 	if emitter.best_width < 0 {


### PR DESCRIPTION
To avoid ROS ssh keys not being wrapped